### PR TITLE
Implementation: Safer event handling on native side

### DIFF
--- a/android/src/main/java/net/mischneider/MSREventBridgeAwareReactRootView.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeAwareReactRootView.java
@@ -9,8 +9,8 @@ import android.util.AttributeSet;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReadableMap;
 
-import net.mischneider.MSREventBridgeEventReceiver;
-import net.mischneider.MSREventBridgeReceiverCallback;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A ReactRootView that implements the {@link MSREventBridgeEventReceiver}.
@@ -39,18 +39,26 @@ public class MSREventBridgeAwareReactRootView extends ReactRootView implements M
     }
 
     @Override
-    public void onEvent(String name, ReadableMap info) {
+    public List<String> supportedEvents() {
         if (_eventBridgeEventReceiver == null) {
-            return;
+            return new ArrayList<>();
         }
-        _eventBridgeEventReceiver.onEvent(name, info);
+        return _eventBridgeEventReceiver.supportedEvents();
     }
 
     @Override
-    public void onEventCallback(String name, ReadableMap info, MSREventBridgeReceiverCallback callback) {
+    public boolean onEvent(String name, ReadableMap info) {
         if (_eventBridgeEventReceiver == null) {
-            return;
+            return false;
         }
-        _eventBridgeEventReceiver.onEventCallback(name, info, callback);
+        return _eventBridgeEventReceiver.onEvent(name, info);
+    }
+
+    @Override
+    public boolean onEventCallback(String name, ReadableMap info, MSREventBridgeReceiverCallback callback) {
+        if (_eventBridgeEventReceiver == null) {
+            return false;
+        }
+        return _eventBridgeEventReceiver.onEventCallback(name, info, callback);
     }
 }

--- a/android/src/main/java/net/mischneider/MSREventBridgeEventReceiver.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeEventReceiver.java
@@ -1,20 +1,27 @@
 package net.mischneider;
 
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
+
+import java.util.List;
 
 /**
  * Handler that receive events posted from a subcomponent. Usually this interface is implemented by
  * an Activity
  */
 public interface MSREventBridgeEventReceiver {
+
+    /**
+     * @return Return a list of supported event names.
+     */
+    List<String> supportedEvents();
+
     /**
      * Event received from React Native
      */
-    void onEvent(String name, ReadableMap info);
+    boolean onEvent(String name, ReadableMap info);
 
     /**
      * Event received from React Native. The callback must be called.
      */
-    void onEventCallback(String name, ReadableMap info, MSREventBridgeReceiverCallback callback);
+    boolean onEventCallback(String name, ReadableMap info, MSREventBridgeReceiverCallback callback);
 }

--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.AssertionException;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -33,6 +34,8 @@ import java.util.Map;
  * Module that handles receiving and sending events from and to React Native
  */
 public class MSREventBridgeModule extends ReactContextBaseJavaModule implements MSREventBridgeEventEmitter {
+
+  public static final String TAG = "MSREventBridgeModule";
 
   // Static Identifier for events that are sent to React Native. These needs to be in sync with iOS!
   private static final String EventBridgeModuleName = "MSREventBridge";
@@ -123,11 +126,16 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
 
         List<String> supportedEvents = receiver.supportedEvents();
         if (!supportedEvents.contains(name)) {
+          if (BuildConfig.DEBUG) {
+            Log.d(TAG, String.format("%s is not a supported event type for %s. Supported events are: `%s`", name, receiver.getClass().getName(), supportedEvents.toString()));
+          }
           return;
         }
 
         boolean eventHandled = receiver.onEvent(name, info);
-        // TODO: Throw an assertion if eventHandled == false
+        if (BuildConfig.DEBUG && !eventHandled) {
+          throw new AssertionException(String.format("Event supported but not handled: <name: %s, info:%s>", name, info.toString()));
+        }
       }
     });
   }
@@ -153,9 +161,11 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
           return;
         }
 
-
         List<String> supportedEvents = receiver.supportedEvents();
         if (!supportedEvents.contains(name)) {
+          if (BuildConfig.DEBUG) {
+            Log.d(TAG, String.format("%s is not a supported event type for %s. Supported events are: `%s`", name, receiver.getClass().getName(), supportedEvents.toString()));
+          }
           return;
         }
 
@@ -170,7 +180,10 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
             callback.invoke(data, null);
           }
         });
-        // TODO: Throw an assertion if eventHandled == false
+
+        if (BuildConfig.DEBUG && !eventHandled) {
+          throw new AssertionException(String.format("Event supported but not handled: <name: %s, info:%s>", name, info.toString()));
+        }
       }
     });
   }

--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -115,27 +115,17 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
       public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
         View view = nativeViewHierarchyManager.resolveView(rootTag);
 
-        MSREventBridgeEventReceiver receiver = null;
-        if (view instanceof MSREventBridgeEventReceiver) {
-          receiver = (MSREventBridgeEventReceiver) view;
-        } else if (view.getContext() instanceof MSREventBridgeEventReceiver) {
-          receiver = (MSREventBridgeEventReceiver)view.getContext();
-        } else {
+        MSREventBridgeEventReceiver receiver = eventReceiverForView(view);
+        if (receiver == null) {
           return;
         }
 
-        List<String> supportedEvents = receiver.supportedEvents();
-        if (!supportedEvents.contains(name)) {
-          if (BuildConfig.DEBUG) {
-            Log.d(TAG, String.format("%s is not a supported event type for %s. Supported events are: `%s`", name, receiver.getClass().getName(), supportedEvents.toString()));
-          }
+        if (!receiverSupportsEventWithName(receiver, name)) {
           return;
         }
 
         boolean eventHandled = receiver.onEvent(name, info);
-        if (BuildConfig.DEBUG && !eventHandled) {
-          throw new AssertionException(String.format("Event supported but not handled: <name: %s, info:%s>", name, info.toString()));
-        }
+        handleReceiverEventHandledResponse(eventHandled, name, info);
       }
     });
   }
@@ -152,20 +142,12 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
       public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
         View view = nativeViewHierarchyManager.resolveView(rootTag);
 
-        MSREventBridgeEventReceiver receiver = null;
-        if (view instanceof MSREventBridgeEventReceiver) {
-          receiver = (MSREventBridgeEventReceiver) view;
-        } else if (view.getContext() instanceof MSREventBridgeEventReceiver) {
-          receiver = (MSREventBridgeEventReceiver) view.getContext();
-        } else {
+        MSREventBridgeEventReceiver receiver = eventReceiverForView(view);
+        if (receiver == null) {
           return;
         }
 
-        List<String> supportedEvents = receiver.supportedEvents();
-        if (!supportedEvents.contains(name)) {
-          if (BuildConfig.DEBUG) {
-            Log.d(TAG, String.format("%s is not a supported event type for %s. Supported events are: `%s`", name, receiver.getClass().getName(), supportedEvents.toString()));
-          }
+        if (!receiverSupportsEventWithName(receiver, name)) {
           return;
         }
 
@@ -180,12 +162,40 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
             callback.invoke(data, null);
           }
         });
-
-        if (BuildConfig.DEBUG && !eventHandled) {
-          throw new AssertionException(String.format("Event supported but not handled: <name: %s, info:%s>", name, info.toString()));
-        }
+        handleReceiverEventHandledResponse(eventHandled, name, info);
       }
     });
+  }
+
+  @Nullable
+  private MSREventBridgeEventReceiver eventReceiverForView(final View view) {
+    if (view instanceof MSREventBridgeEventReceiver) {
+      return (MSREventBridgeEventReceiver) view;
+    } else if (view.getContext() instanceof MSREventBridgeEventReceiver) {
+      return (MSREventBridgeEventReceiver) view.getContext();
+    } else {
+      return null;
+    }
+  }
+
+  private boolean receiverSupportsEventWithName(final MSREventBridgeEventReceiver receiver, final String name) {
+    List<String> supportedEvents = receiver.supportedEvents();
+    if (!supportedEvents.contains(name)) {
+      if (BuildConfig.DEBUG) {
+        Log.d(TAG, String.format("%s is not a supported event type for %s. Supported events are: `%s`", name, receiver.getClass().getName(), supportedEvents.toString()));
+      }
+      return false;
+    }
+
+    return true;
+  }
+
+  private void handleReceiverEventHandledResponse(boolean eventHandled, final String name, final ReadableMap info) {
+    if (BuildConfig.DEBUG || eventHandled) {
+      return;
+    }
+
+    throw new AssertionException(String.format("Event supported but not handled: <name: %s, info:%s>", name, info.toString()));
   }
 
   // Emit Events

--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -111,17 +111,23 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
       @Override
       public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
         View view = nativeViewHierarchyManager.resolveView(rootTag);
+
+        MSREventBridgeEventReceiver receiver = null;
         if (view instanceof MSREventBridgeEventReceiver) {
-          MSREventBridgeEventReceiver receiver = (MSREventBridgeEventReceiver) view;
-          receiver.onEvent(name, info);
+          receiver = (MSREventBridgeEventReceiver) view;
+        } else if (view.getContext() instanceof MSREventBridgeEventReceiver) {
+          receiver = (MSREventBridgeEventReceiver)view.getContext();
+        } else {
           return;
         }
 
-        Context context = view.getContext();
-        if (context instanceof MSREventBridgeEventReceiver) {
-          MSREventBridgeEventReceiver receiver = (MSREventBridgeEventReceiver)context;
-          receiver.onEvent(name, info);
+        List<String> supportedEvents = receiver.supportedEvents();
+        if (!supportedEvents.contains(name)) {
+          return;
         }
+
+        boolean eventHandled = receiver.onEvent(name, info);
+        // TODO: Throw an assertion if eventHandled == false
       }
     });
   }
@@ -147,7 +153,13 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
           return;
         }
 
-        receiver.onEventCallback(name, info, new MSREventBridgeReceiverCallback() {
+
+        List<String> supportedEvents = receiver.supportedEvents();
+        if (!supportedEvents.contains(name)) {
+          return;
+        }
+
+        boolean eventHandled = receiver.onEventCallback(name, info, new MSREventBridgeReceiverCallback() {
           @Override
           public void onSuccess(Object data) {
             callback.invoke(null, data);
@@ -158,6 +170,7 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
             callback.invoke(data, null);
           }
         });
+        // TODO: Throw an assertion if eventHandled == false
       }
     });
   }

--- a/android/src/main/java/net/mischneider/MSREventBridgePackage.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgePackage.java
@@ -12,7 +12,7 @@ import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 
 public class MSREventBridgePackage implements ReactPackage {
-    // Deprecated RN 0.47
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
@@ -73,24 +73,29 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
             return true;
         }
 
-        // Example to just present a new activity
-        if (name.equals(PresentScreenEventName)) {
+        // Handle presenting a new activity
+        else if (name.equals(PresentScreenEventName)) {
             Intent myIntent = new Intent(getBaseContext(), SecondActivity.class);
             startActivity(myIntent);
             return true;
         }
 
         // Handle dismiss a screen
-        if (name.equals(DismissScreenEventName)) {
+        else if (name.equals(DismissScreenEventName)) {
             finish();
             return true;
         }
 
-        // Emit callback event
-        WritableMap map = new WritableNativeMap();
-        map.putString("eventName", name);
-        MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
-        return true;
+        // Handle Learn More
+        else if (name.equals(LearnMoreEventName)) {
+            // Emit callback event
+            WritableMap map = new WritableNativeMap();
+            map.putString("eventName", name);
+            MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+            return true;
+        }
+
+        return false;
     }
 
     @Override
@@ -119,10 +124,15 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
             return true;
         }
 
-        // Emit callback
-        WritableMap map = new WritableNativeMap();
-        map.putString("key", "value");
-        callback.onSuccess(map);
-        return true;
+        // Handle an event with callback
+        else if (name.equals(EventWithCallbackEventName)) {
+            // Emit callback
+            WritableMap map = new WritableNativeMap();
+            map.putString("key", "value");
+            callback.onSuccess(map);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
@@ -70,6 +70,7 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
             WritableMap map = new WritableNativeMap();
             map.putString("rowSelected", ""+rowID);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+
             return true;
         }
 
@@ -77,24 +78,27 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
         else if (name.equals(PresentScreenEventName)) {
             Intent myIntent = new Intent(getBaseContext(), SecondActivity.class);
             startActivity(myIntent);
+
             return true;
         }
 
         // Handle dismiss a screen
         else if (name.equals(DismissScreenEventName)) {
             finish();
+
             return true;
         }
 
         // Handle Learn More
         else if (name.equals(LearnMoreEventName)) {
-            // Emit callback event
             WritableMap map = new WritableNativeMap();
             map.putString("eventName", name);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+
             return true;
         }
 
+        // In this case we don't handle the event
         return false;
     }
 
@@ -126,13 +130,13 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
 
         // Handle an event with callback
         else if (name.equals(EventWithCallbackEventName)) {
-            // Emit callback
             WritableMap map = new WritableNativeMap();
             map.putString("key", "value");
             callback.onSuccess(map);
             return true;
         }
 
+        // In this case we don't handle the event
         return false;
     }
 }

--- a/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/MainActivity.java
@@ -5,7 +5,6 @@ import android.os.Handler;
 import android.util.Log;
 
 import com.facebook.react.ReactActivity;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -17,6 +16,9 @@ import net.mischneider.MSREventBridgeEventReceiver;
 import net.mischneider.MSREventBridgeInstanceManagerProvider;
 import net.mischneider.MSREventBridgeReceiverCallback;
 import net.mischneider.MSREventBridgeModule;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class MainActivity extends ReactActivity implements MSREventBridgeEventReceiver {
 
@@ -32,13 +34,27 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
 
     // EventBridgeEventReceiver
 
+    final static String LearnMoreEventName = "LearnMore";
+    final static String EventWithCallbackEventName = "EventWithCallback";
     final static String LoadDataEventName = "LoadData";
     final static String DidSelectRowEventName = "DidSelectRow";
     final static String PresentScreenEventName = "PresentScreen";
     final static String DismissScreenEventName = "DismissScreen";
 
     @Override
-    public void onEvent(final String name, final ReadableMap info) {
+    public List<String> supportedEvents() {
+        return Arrays.asList(
+                LearnMoreEventName,
+                EventWithCallbackEventName,
+                LoadDataEventName,
+                DidSelectRowEventName,
+                PresentScreenEventName,
+                DismissScreenEventName
+        );
+    }
+
+    @Override
+    public boolean onEvent(final String name, final ReadableMap info) {
         Log.d(ReactConstants.TAG, this.getClass().getName() + ": Received event: ".concat(name));
 
         MSREventBridgeInstanceManagerProvider instanceManagerProvider =
@@ -54,30 +70,31 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
             WritableMap map = new WritableNativeMap();
             map.putString("rowSelected", ""+rowID);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
-            return;
+            return true;
         }
 
         // Example to just present a new activity
         if (name.equals(PresentScreenEventName)) {
             Intent myIntent = new Intent(getBaseContext(), SecondActivity.class);
             startActivity(myIntent);
-            return;
+            return true;
         }
 
         // Handle dismiss a screen
         if (name.equals(DismissScreenEventName)) {
             finish();
-            return;
+            return true;
         }
 
         // Emit callback event
         WritableMap map = new WritableNativeMap();
         map.putString("eventName", name);
         MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+        return true;
     }
 
     @Override
-    public void onEventCallback(final String name, final ReadableMap info, final MSREventBridgeReceiverCallback callback) {
+    public boolean onEventCallback(final String name, final ReadableMap info, final MSREventBridgeReceiverCallback callback) {
         Log.d(ReactConstants.TAG, this.getClass().getName() + ": Received event with callback: ".concat(name));
 
         final String activityClassName = this.getClass().getSimpleName();
@@ -99,12 +116,13 @@ public class MainActivity extends ReactActivity implements MSREventBridgeEventRe
                 }
             }, 2000);
 
-            return;
+            return true;
         }
 
         // Emit callback
         WritableMap map = new WritableNativeMap();
         map.putString("key", "value");
         callback.onSuccess(map);
+        return true;
     }
 }

--- a/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
@@ -78,12 +78,14 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             WritableMap map = new WritableNativeMap();
             map.putString("rowSelected", ""+rowID);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+
             return true;
         }
 
         // Handle dismiss screen event
         else if (name.equals(DismissScreenEventName)) {
             finish();
+
             return true;
         }
         else if (name.equals(LearnMoreEventName)) {
@@ -92,6 +94,7 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             WritableMap map = new WritableNativeMap();
             map.putString("eventName", name);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+
             return true;
         }
 
@@ -133,6 +136,7 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             WritableMap map = new WritableNativeMap();
             map.putString("key", "value");
             callback.onSuccess(map);
+
             return true;
         }
 

--- a/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
@@ -86,12 +86,17 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             finish();
             return true;
         }
+        else if (name.equals(LearnMoreEventName)) {
 
-        // Emit callback event
-        WritableMap map = new WritableNativeMap();
-        map.putString("eventName", name);
-        MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
-        return true;
+            // Emit callback event
+            WritableMap map = new WritableNativeMap();
+            map.putString("eventName", name);
+            MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+            return true;
+        }
+
+        return false;
+
     }
 
     @Override
@@ -123,10 +128,14 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             return true;
         }
 
-        // Emit callback
-        WritableMap map = new WritableNativeMap();
-        map.putString("key", "value");
-        callback.onSuccess(map);
-        return true;
+        else if (name.equals(EventWithCallbackEventName)) {
+            // Emit callback
+            WritableMap map = new WritableNativeMap();
+            map.putString("key", "value");
+            callback.onSuccess(map);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
+++ b/example/android/app/src/main/java/com/eventbridgeexample/SecondActivity.java
@@ -5,7 +5,6 @@ import android.util.Log;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -17,6 +16,9 @@ import net.mischneider.MSREventBridgeEventReceiver;
 import net.mischneider.MSREventBridgeInstanceManagerProvider;
 import net.mischneider.MSREventBridgeModule;
 import net.mischneider.MSREventBridgeReceiverCallback;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SecondActivity extends ReactActivity implements MSREventBridgeEventReceiver, MSREventBridgeInstanceManagerProvider {
 
@@ -41,12 +43,25 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
      * EventBridgeEventReceiver
      */
 
+    final static String LearnMoreEventName = "LearnMore";
+    final static String EventWithCallbackEventName = "EventWithCallback";
     final static String LoadDataEventName = "LoadData";
     final static String DidSelectRowEventName = "DidSelectRow";
     final static String DismissScreenEventName = "DismissScreen";
 
     @Override
-    public void onEvent(final String name, final ReadableMap info) {
+    public List<String> supportedEvents() {
+        return Arrays.asList(
+                LearnMoreEventName,
+                EventWithCallbackEventName,
+                LoadDataEventName,
+                DidSelectRowEventName,
+                DismissScreenEventName
+        );
+    }
+
+    @Override
+    public boolean onEvent(final String name, final ReadableMap info) {
         Log.d(ReactConstants.TAG, this.getClass().getName() + ": Received event: ".concat(name));
 
         MSREventBridgeInstanceManagerProvider instanceManagerProvider =
@@ -63,23 +78,24 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
             WritableMap map = new WritableNativeMap();
             map.putString("rowSelected", ""+rowID);
             MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
-            return;
+            return true;
         }
 
         // Handle dismiss screen event
         else if (name.equals(DismissScreenEventName)) {
             finish();
-            return;
+            return true;
         }
 
         // Emit callback event
         WritableMap map = new WritableNativeMap();
         map.putString("eventName", name);
         MSREventBridgeModule.emitEventForActivity(this, instanceManagerProvider, "eventName", map);
+        return true;
     }
 
     @Override
-    public void onEventCallback(final String name, final ReadableMap info, final MSREventBridgeReceiverCallback callback) {
+    public boolean onEventCallback(final String name, final ReadableMap info, final MSREventBridgeReceiverCallback callback) {
         Log.d(ReactConstants.TAG, this.getClass().getName() + ": Received event  with callback: ".concat(name));
 
         final String activityClassName = this.getClass().getSimpleName();
@@ -104,12 +120,13 @@ public class SecondActivity extends ReactActivity implements MSREventBridgeEvent
                 }
             }, 2000);
 
-            return;
+            return true;
         }
 
         // Emit callback
         WritableMap map = new WritableNativeMap();
         map.putString("key", "value");
         callback.onSuccess(map);
+        return true;
     }
 }

--- a/example/ios/EventBridgeExample/AppDelegate.m
+++ b/example/ios/EventBridgeExample/AppDelegate.m
@@ -158,7 +158,7 @@ static NSString * const DidSelectRowEvent = @"DidSelectRow";
 
 #pragma mark - <MSREventBridgeEventReceiver>
 
-- (NSArray *)supportedEvents
+- (NSArray<NSString *> *)supportedEvents
 {
   static NSArray *supportedEvents = nil;
   static dispatch_once_t onceToken;

--- a/ios/MSREventBridge.h
+++ b/ios/MSREventBridge.h
@@ -54,7 +54,7 @@ typedef void (^MSREventBridgeEventReceiverCallback)(NSError * _Nullable error, i
 /**
  * Return an array of supported events.
  */
-- (NSArray *)supportedEvents;
+- (NSArray<NSString *> *)supportedEvents;
 
 @optional
 

--- a/ios/MSREventBridge.h
+++ b/ios/MSREventBridge.h
@@ -51,17 +51,24 @@ typedef void (^MSREventBridgeEventReceiverCallback)(NSError * _Nullable error, i
  */
 @protocol MSREventBridgeEventReceiver <NSObject>
 
+/**
+ * Return an array of supported events.
+ */
+- (NSArray *)supportedEvents;
+
 @optional
 
 /**
- * Event received from React Native
+ * Handle event received from React Native. Return YES if the event will be handled, otherwise if the event will not
+ * be handled an assertion will happen in development.
  */
-- (void)onEventWithName:(NSString *)name info:(nullable NSDictionary *)info;
+- (BOOL)onEventWithName:(NSString *)name info:(nullable NSDictionary *)info;
 
 /**
- * Event received from React Native. The callback must be called.
+ * Event received from React Native. The callback must be called. Return YES if the event will be handled, otherwise if
+ * the event will not be handled an assertion will happen in development.
  */
-- (void)onEventWithName:(NSString *)name info:(nullable  NSDictionary *)info callback:(nullable MSREventBridgeEventReceiverCallback)callback;
+- (BOOL)onEventWithName:(NSString *)name info:(nullable  NSDictionary *)info callback:(nullable MSREventBridgeEventReceiverCallback)callback;
 
 @end
 

--- a/ios/MSREventBridge.m
+++ b/ios/MSREventBridge.m
@@ -39,14 +39,22 @@ RCT_EXPORT_METHOD(onEvent:(nonnull NSNumber *)reactTag name:(NSString *)name inf
     // Check if root view can receive the event
     if ([rootView conformsToProtocol:@protocol(MSREventBridgeEventReceiver)]
         && [rootView respondsToSelector:@selector(onEventWithName:info:)]) {
-      [(id<MSREventBridgeEventReceiver>)rootView onEventWithName:name info:info];
+      NSArray *supportedEvents = [(id<MSREventBridgeEventReceiver>)rootView supportedEvents];
+      if ([supportedEvents containsObject:name]) {
+        BOOL handled = [(id<MSREventBridgeEventReceiver>)rootView onEventWithName:name info:info];
+        NSAssert(handled, @"Event supported but not handled: <name: %@, info:%@>",name, info);
+      }
     }
     
     // Check if the view controller of the root view can receive the event
     UIViewController *viewController = rootView.reactViewController;
     if ([viewController conformsToProtocol:@protocol(MSREventBridgeEventReceiver)]
         && [viewController respondsToSelector:@selector(onEventWithName:info:)]) {
-      [(id<MSREventBridgeEventReceiver>)viewController onEventWithName:name info:info];
+      NSArray *supportedEvents = [(id<MSREventBridgeEventReceiver>)viewController supportedEvents];
+      if ([supportedEvents containsObject:name]) {
+        BOOL handled = [(id<MSREventBridgeEventReceiver>)viewController onEventWithName:name info:info];
+        NSAssert(handled, @"Event supported but not handled: <name: %@, info:%@>",name, info);
+      }
     }
   }];
 }
@@ -57,17 +65,25 @@ RCT_EXPORT_METHOD(onEventCallback:(nonnull NSNumber *)reactTag name:(NSString *)
     // Check if root view can receive the event
     if ([rootView conformsToProtocol:@protocol(MSREventBridgeEventReceiver)]
         && [rootView respondsToSelector:@selector(onEventWithName:info:callback:)]) {
-      [(id<MSREventBridgeEventReceiver>)rootView onEventWithName:name info:info callback:^(NSError *error, id data) {
-        callback(@[(error ?: [NSNull null]), (data ?: [NSNull null])]);
-      }];
+        NSArray *supportedEvents = [(id<MSREventBridgeEventReceiver>)rootView supportedEvents];
+        if ([supportedEvents containsObject:name]) {
+          BOOL handled = [(id<MSREventBridgeEventReceiver>)rootView onEventWithName:name info:info callback:^(NSError *error, id data) {
+            callback(@[(error ?: [NSNull null]), (data ?: [NSNull null])]);
+          }];
+          NSAssert(handled, @"Event supported but not handled: <name: %@, info:%@>",name, info);
+        }
     } else {
       // Check if the view controller of the root view can receive the event
       UIViewController *viewController = rootView.reactViewController;
       if ([viewController conformsToProtocol:@protocol(MSREventBridgeEventReceiver)]
           && [viewController respondsToSelector:@selector(onEventWithName:info:callback:)]) {
-        [(id<MSREventBridgeEventReceiver>)viewController onEventWithName:name info:info callback:^(NSError *error, id data) {
-          callback(@[(error ?: [NSNull null]), (data ?: [NSNull null])]);
-        }];
+        NSArray *supportedEvents = [(id<MSREventBridgeEventReceiver>)viewController supportedEvents];
+        if ([supportedEvents containsObject:name]) {
+          BOOL handled = [(id<MSREventBridgeEventReceiver>)viewController onEventWithName:name info:info callback:^(NSError *error, id data) {
+            callback(@[(error ?: [NSNull null]), (data ?: [NSNull null])]);
+          }];
+          NSAssert(handled, @"Event supported but not handled: <name: %@, info:%@>",name, info);
+        }
       }
     }
   }];


### PR DESCRIPTION
Related issue: #12 

The initial work is now done on iOS and Android.

The current implementation would have a breaking API change. We may should integrate it more incrementally:
We should have two protocols (iOS) / interfaces (Android) and check on runtime if the receiver implements the first or second interface:
   - `MSREventBridgeEventReceiver`
   - `MSREventBridgeSafeEventReceiver`

This should be realizable on iOS and Android 

TODO:
- [ ] Implement `MSREventBridgeSafeEventReceiver` on iOS
- [ ] Implement `MSREventBridgeSafeEventReceiver` on Android
- [ ] Documentation