### PR TITLE
Switch RN module import fallbacks in iOS

### DIFF
--- a/ios/MSREventBridge.h
+++ b/ios/MSREventBridge.h
@@ -5,13 +5,12 @@
 //  Copyright © 2017 mischneider. All rights reserved.
 //
 
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#else // Compatibility for RN version < 0.40
+#import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
See this issue for reference: https://github.com/facebook/react-native/issues/15775#issuecomment-327082159

Seems like React doesn't like it when the fallback is the *new* import, the fallback should be the old way.