### PR TITLE
Support React root views which aren't children of content view

### DIFF
--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -210,8 +210,8 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
     // Get the root view
     ViewGroup contentView = (ViewGroup) activity.findViewById(android.R.id.content);
     View view = findRootView(contentView);
-    if (view == null) {
-      view = contentView;
+    if (!(view instanceof RootView) {
+      return;
     }
 
     // React tag is the identifier to be able to detect in ReactNativewhich component should receive
@@ -259,7 +259,6 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
         }
       }
     }
-
     return null;
   }
 

--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -208,14 +208,10 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
    */
   public void emitEventForActivity(Activity activity, final String name, @Nullable WritableMap info)  {
     // Get the root view
-    View view = activity.findViewById(android.R.id.content);
-    ViewGroup viewGroup = (ViewGroup)view;
-    for (int i = 0; i < viewGroup.getChildCount(); i++) {
-      View child = viewGroup.getChildAt(i);
-      if (child instanceof RootView) {
-        view = child;
-        break;
-      }
+    ViewGroup contentView = (ViewGroup) activity.findViewById(android.R.id.content);
+    View view = findRootView(contentView);
+    if (view == null) {
+      view = contentView;
     }
 
     // React tag is the identifier to be able to detect in ReactNativewhich component should receive
@@ -245,6 +241,26 @@ public class MSREventBridgeModule extends ReactContextBaseJavaModule implements 
             .getEventBridgeReactInstanceManager()
             .getCurrentReactContext()
             .getNativeModule(MSREventBridgeModule.class);
+  }
+
+  /**
+   * Returns the descendant of the given view which is the root of the React Native views
+   */
+  @Nullable
+  private View findRootView(ViewGroup parent) {
+    for (int i = 0; i < parent.getChildCount(); i++) {
+      View child = parent.getChildAt(i);
+      if (child instanceof RootView) {
+        return child;
+      } else if (child instanceof ViewGroup) {
+        child = findRootView((ViewGroup) child);
+        if (child != null) {
+          return child;
+        }
+      }
+    }
+
+    return null;
   }
 
 }


### PR DESCRIPTION
...on Android.

Previously only direct children of the content view would be checked for
being a `RootView`. This change allows any descendant of the content
view to be considered as the `RootView`.

This is useful for example when embedding React Native into an existing
native app. In cases like this, there may be native views which are
direct children of the content view, and the React Native root may be
further down the View hierarchy.

Without this change, when the React Native root was deeper in the View
hierarchy, it wasn't possible to send events to it via
`MSREventBridgeModule#emitEventForActivity`.