### PR TITLE
Updates Maven RN Reference

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
 
 repositories {
     maven {
-        url "${project.rootDir}/../example/node_modules/react-native/android"
+        url "$projectDir/../node_modules/react-native/android"
     }
     mavenCentral()
 }


### PR DESCRIPTION
Before the reference was pointing at the node_modules folder in the example directly. When the example is not initialized, the lib / AS project would fail to compile.
This fixes it so that the native dependencies build without the example having been initialized.