### PR TITLE
Update Android build.gradle to follow sdk version of the parent project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,13 +12,17 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion safeExtGet('compileSdkVersion', 25)
+    buildToolsVersion safeExtGet('buildToolsVersion', '25.0.0')
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion safeExtGet('targetSdkVersion', 25)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
In this changes, build.gradle will check whether parent project has defined SDK version. Otherwise it will fall back to default value.