### PR TITLE
Fix for Could not find @ReactModule annotation issue

### DIFF
--- a/android/src/main/java/net/mischneider/MSREventBridgeModule.java
+++ b/android/src/main/java/net/mischneider/MSREventBridgeModule.java
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.RootView;
@@ -32,6 +33,7 @@ import java.util.Map;
 /**
  * Module that handles receiving and sending events from and to React Native
  */
+@ReactModule(name = "MSREventBridge")
 public class MSREventBridgeModule extends ReactContextBaseJavaModule implements MSREventBridgeEventEmitter {
 
   // Static Identifier for events that are sent to React Native. These needs to be in sync with iOS!


### PR DESCRIPTION
RN 0.58 adds the breaking change that 

> Native Modules in Android now require @ReactModule annotations to access .getNativeModule method on the ReactContext

https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#breaking-changes-

This PR adds the annotation. 